### PR TITLE
7.0-Clean: sdhci-pci-core: Remove unneeded quirks for sdhci_aeolia

### DIFF
--- a/drivers/mmc/host/sdhci-pci-core.c
+++ b/drivers/mmc/host/sdhci-pci-core.c
@@ -398,12 +398,6 @@ static const struct sdhci_pci_fixes sdhci_aeolia = {
 	.probe_slot	= aeolia_probe_slot,
 	.remove_slot	= aeolia_remove_slot,
 	.enable_dma	= aeolia_enable_dma,
-	.quirks		= SDHCI_QUIRK_BROKEN_TIMEOUT_VAL |
-			  SDHCI_QUIRK_DELAY_AFTER_POWER |
-			  SDHCI_QUIRK_SINGLE_POWER_WRITE,
-	.quirks2	= SDHCI_QUIRK2_PRESET_VALUE_BROKEN,
-			  SDHCI_QUIRK2_CLOCK_DIV_ZERO_BROKEN,
-			  SDHCI_QUIRK2_TUNING_WORK_AROUND,
 };
 #endif
 


### PR DESCRIPTION
These were left in from the time of the CUH-1216 SDHCI fix search, accidentally left out from deletion.

The SDHCI stack should be fine on all three SB's with these quirks reverted.