### PR TITLE
7.0-Clean: build.sh: Stop build if custom FW request is absent in worktree (sd8797)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -21,6 +21,7 @@ OUTPUT_DIR="${PWD}/out"
 FIRMWARE_DIR="${PWD}/extra_firmware"
 FIRMWARE_URL_BASE="https://gitlab.com/kernel-firmware/linux-firmware/-/raw/main"
 declare -A FIRMWARE_URL_OVERRIDES
+FIRMWARE_URL_OVERRIDES["mrvl/sd8797_uapsta.bin"]="useCustomFirmware" # Prevent download from upstream; use Orbis/Custom one
 #FIRMWARE_URL_OVERRIDES["mrvl/sd8797_uapsta.bin"]="f87c5b8dd547bcb434d5296ead3748241810c1d8" #sucks too
 # We need an older firmware version from ~2013-2016 for Aeolias' 8797 SDIO Chip, ideally the one that's used on the PS4 OS.
 # This version is the closest to that we have (besides the one packed in Orbis Torus (WiFi+BT) firmware).
@@ -241,6 +242,11 @@ if [[ "$DO_FETCH" == "1" ]]; then
             FIRMWARE_URL_FALLBACK=""
 
             if [[ -n "${FIRMWARE_URL_OVERRIDES[$blob]:-}" ]]; then
+                if [[ ${FIRMWARE_URL_OVERRIDES[$blob]} == "useCustomFirmware" ]]; then
+                    echo -e "  \e[1;31mERROR:\e[0m Requested custom built-in firmware for ${blob}, but it was not found in build directory.\n"\
+                            " Please ensure the proper firmware exists in ${FIRMWARE_DIR}/${blob} . Exiting with error." >&2
+                    exit 1
+                fi
                 COMMIT="${FIRMWARE_URL_OVERRIDES[$blob]}"
                 FIRMWARE_URL_FALLBACK="https://gitlab.com/kernel-firmware/linux-firmware/-/raw/${COMMIT}"
             fi


### PR DESCRIPTION
These overridden FW should be sourced manually instead of from upstream.